### PR TITLE
feat: 카테고리 탭을 드롭다운 메뉴로 개선

### DIFF
--- a/src/components/post-tabs/index.js
+++ b/src/components/post-tabs/index.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Tabs, Tab } from '@mui/material';
+import { Select, MenuItem, FormControl, InputLabel, Box } from '@mui/material';
 import PostCardColumn from '../post-card-column';
 import './style.scss';
 
@@ -9,20 +9,36 @@ function PostTabs({ tabIndex, onChange, tabs, posts, showMoreButton }) {
     return posts.filter((post) => post.categories.includes(tabs[tabIndex]));
   }, [posts, tabs, tabIndex]);
 
+  const handleSelectChange = (event) => {
+    const newIndex = event.target.value;
+    onChange(event, newIndex);
+  };
+
   return (
     <div className="post-tabs-wrapper">
-      <div className="post-tabs">
-        <Tabs
-          className="mui-tabs"
-          value={tabIndex}
-          onChange={onChange}
-          variant="scrollable"
-          scrollButtons="desktop"
-        >
-          {tabs.map((title, index) => (
-            <Tab label={title} key={index} />
-          ))}
-        </Tabs>
+      <div className="post-category-selector">
+        <FormControl className="category-select-form">
+          <InputLabel id="category-select-label">카테고리</InputLabel>
+          <Select
+            labelId="category-select-label"
+            id="category-select"
+            value={tabIndex}
+            label="카테고리"
+            onChange={handleSelectChange}
+            className="category-select"
+          >
+            {tabs.map((title, index) => (
+              <MenuItem key={index} value={index} className="category-menu-item">
+                <Box display="flex" alignItems="center" gap={1}>
+                  <span>{title}</span>
+                  <span className="post-count">
+                    ({title === 'All' ? posts.length : posts.filter(post => post.categories.includes(title)).length})
+                  </span>
+                </Box>
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </div>
       <PostCardColumn
         posts={showMoreButton ? tabPosts.slice(0, 4) : tabPosts}

--- a/src/components/post-tabs/style.scss
+++ b/src/components/post-tabs/style.scss
@@ -9,54 +9,107 @@
   top: 0px;
   width: 100%;
 
-  .post-tabs {
+  .post-category-selector {
     display: flex;
     justify-content: center;
-    height: 40px;
     width: 100%;
     max-width: $content-max-width + 40px;
-    margin-bottom: 12px;
+    margin-bottom: 24px;
 
-    .mui-tabs {
-      .MuiTab-root {
-        height: 40px;
-        min-height: auto;
-        min-width: auto;
-        padding: 10px 12px;
+    .category-select-form {
+      min-width: 200px;
+      max-width: 300px;
+      width: 100%;
+
+      .MuiInputLabel-root {
         font-family: $font-family;
         color: var(--tab-text-color);
         font-weight: 500;
-        font-size: 17px;
-        transition: all 200ms ease;
-
-        :hover {
+        
+        &.Mui-focused {
           color: var(--tab-hover-text-color);
-          transition: all 200ms ease;
         }
       }
 
-      .Mui-selected {
-        background-color: var(--tab-selected-background-color);
-        color: var(--tab-hover-text-color);
+      .category-select {
+        font-family: $font-family;
+        color: var(--tab-text-color);
         border-radius: 8px;
-        font-weight: 600;
-        transition: all 200ms ease;
-      }
+        
+        .MuiOutlinedInput-notchedOutline {
+          border-color: var(--tab-text-color);
+          opacity: 0.3;
+        }
+        
+        &:hover .MuiOutlinedInput-notchedOutline {
+          border-color: var(--tab-hover-text-color);
+          opacity: 0.7;
+        }
+        
+        &.Mui-focused .MuiOutlinedInput-notchedOutline {
+          border-color: var(--tab-hover-text-color);
+        }
 
-      .MuiTabScrollButton-root {
-        height: 40px;
-        width: 20px;
-      }
+        .MuiSelect-select {
+          padding: 12px 14px;
+          font-size: 16px;
+          font-weight: 500;
+        }
 
-      .MuiTabs-scrollable {
-        height: 40px;
-      }
-
-      .MuiTabs-indicator {
-        display: none;
+        .MuiSvgIcon-root {
+          color: var(--tab-text-color);
+        }
       }
     }
   }
 
+  .category-menu-item {
+    font-family: $font-family;
+    color: var(--tab-text-color);
+    
+    &:hover {
+      background-color: var(--tab-selected-background-color);
+      color: var(--tab-hover-text-color);
+    }
+    
+    &.Mui-selected {
+      background-color: var(--tab-selected-background-color);
+      color: var(--tab-hover-text-color);
+      font-weight: 600;
+      
+      &:hover {
+        background-color: var(--tab-selected-background-color);
+      }
+    }
 
+    .post-count {
+      opacity: 0.7;
+      font-size: 0.9em;
+      font-weight: 400;
+    }
+  }
+
+  // 반응형 디자인
+  @media (max-width: 768px) {
+    .post-category-selector {
+      .category-select-form {
+        min-width: 160px;
+        max-width: 200px;
+        
+        .category-select .MuiSelect-select {
+          padding: 10px 12px;
+          font-size: 14px;
+        }
+      }
+    }
+  }
+
+  @media (max-width: 1024px) and (min-width: 769px) {
+    .post-category-selector {
+      .category-select-form {
+        min-width: 180px;
+        max-width: 250px;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- 좌우 스크롤이 필요한 카테고리 탭을 Material-UI Select 드롭다운으로 변경
- 각 카테고리별 게시물 개수를 표시하여 사용성 향상
- 반응형 디자인 적용으로 모바일에서도 최적화된 UI 제공

## Changes
- `src/components/post-tabs/index.js`: Tabs를 Select 컴포넌트로 변경
- `src/components/post-tabs/style.scss`: 드롭다운에 맞는 스타일링 적용

## Test plan
- [x] 로컬 빌드 성공 확인
- [x] 카테고리 선택 기능 정상 작동 확인
- [x] 반응형 디자인 확인
- [x] 기존 테마와 일관성 확인