### PR TITLE
feat: 코드블록 클릭 확장/축소 기능 구현

### DIFF
--- a/src/components/post-content/index.js
+++ b/src/components/post-content/index.js
@@ -1,7 +1,43 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './style.scss';
 
 function PostContent({ html }) {
+  useEffect(() => {
+    const handleCodeBlockExpand = () => {
+      const codeBlocks = document.querySelectorAll('.markdown .highlight pre, .markdown pre');
+      
+      codeBlocks.forEach(codeBlock => {
+        // 이미 이벤트 리스너가 추가되었는지 확인
+        if (codeBlock.dataset.expandHandlerAdded) return;
+        
+        codeBlock.addEventListener('click', (e) => {
+          // 화면 너비가 breakpoint 미만이면 확장 기능 비활성화
+          const screenLgMin = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--screen-lg-min'));
+          if (window.innerWidth < screenLgMin) return;
+          
+          // ::after 가상 요소 클릭 감지
+          const rect = codeBlock.getBoundingClientRect();
+          const clickX = e.clientX - rect.left;
+          const clickY = e.clientY - rect.top;
+          
+          // 우측 상단 영역(아이콘 위치) 클릭 감지
+          if (clickX > rect.width - 40 && clickY < 40) {
+            e.stopPropagation();
+            codeBlock.classList.toggle('expanded');
+          }
+        });
+        
+        // 중복 이벤트 리스너 방지
+        codeBlock.dataset.expandHandlerAdded = 'true';
+      });
+    };
+
+    // DOM이 로드된 후 실행
+    const timer = setTimeout(handleCodeBlockExpand, 100);
+    
+    return () => clearTimeout(timer);
+  }, [html]);
+
   return (
     <div className="post-content">
       <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />

--- a/src/styles/_markdown-style.scss
+++ b/src/styles/_markdown-style.scss
@@ -849,6 +849,49 @@
   line-height: 1.45;
   background-color: #f6f8fa;
   border-radius: 3px;
+  position: relative;
+  transition: all 0.3s ease;
+  width: 720px;
+  margin: 0 auto;
+  
+  &::after {
+    content: '' !important;
+    position: absolute !important;
+    top: 8px !important;
+    right: 12px !important;
+    width: 18px !important;
+    height: 18px !important;
+    cursor: pointer !important;
+    transition: all 0.2s ease !important;
+    z-index: 100 !important;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23999999'%3E%3Cpath d='M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z'/%3E%3C/svg%3E") !important;
+    background-size: contain !important;
+    background-repeat: no-repeat !important;
+    background-position: center !important;
+    
+    @media (max-width: #{$screen-lg-min - 1px}) {
+      display: none !important;
+    }
+  }
+  
+  &::after:hover {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23f0f0f0'%3E%3Cpath d='M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z'/%3E%3C/svg%3E") !important;
+  }
+  
+  &.expanded {
+    width: 1024px;
+    transform: translateX(-152px);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+    
+    &::after {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23999999'%3E%3Cpath d='M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z'/%3E%3C/svg%3E") !important;
+    }
+    
+    &::after:hover {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23f0f0f0'%3E%3Cpath d='M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z'/%3E%3C/svg%3E") !important;
+    }
+  }
 }
 
 .markdown pre code {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -8,3 +8,7 @@ $content-image-max-height: 560px;
 $screen-sm-min: 576px;
 $screen-md-min: 768px;
 $screen-lg-min: 1080px;
+
+:root {
+  --screen-lg-min: #{$screen-lg-min};
+}


### PR DESCRIPTION
## Summary
- 코드블록 우측 상단에 확장/축소 아이콘 추가 (Material UI Fullscreen/Exit 아이콘)
- 클릭 시 720px에서 1024px로 중앙 기준 확장 애니메이션
- 태블릿 이하 화면에서 기능 자동 비활성화

## Test plan
- [ ] 데스크톱에서 코드블록 아이콘 표시 확인
- [ ] 확장/축소 애니메이션 동작 확인
- [ ] 태블릿/모바일에서 아이콘 숨김 및 기능 비활성화 확인