### PR TITLE
검색 입력창 FOUC 문제 해결

### DIFF
--- a/src/components/page-header/style.scss
+++ b/src/components/page-header/style.scss
@@ -5,13 +5,18 @@
   justify-content: center;
   width: 100%;
   height: 60px;
-
+  // FOUC 방지를 위한 안정적인 초기 상태
+  min-height: 60px;
+  box-sizing: border-box;
 
   .page-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     @include content-max-width;
+    // 레이아웃 안정성 확보
+    min-height: 60px;
+    width: 100%;
 
     .link {
       font-weight: 700;
@@ -27,16 +32,19 @@
     .trailing-section {
       display: flex;
       align-items: center;
+      // 검색창 안정성을 위한 추가 설정
+      flex-shrink: 0;
+      min-height: 32px;
 
       .link {
         margin-right: 10px;
-
+        // 텍스트 렌더링 안정성
+        white-space: nowrap;
+        
         @include md {
           margin-right: 20px;
         }
       }
-
-
     }
   }
 }

--- a/src/components/post-search/style.scss
+++ b/src/components/post-search/style.scss
@@ -3,13 +3,18 @@
 
 
 .search-input-wrapper {
-    display: none;
+    // FOUC 방지를 위한 초기 스타일 안정화
+    display: flex;
     align-items: center;
     width: 180px;
     margin-top: 3px;
-
+    visibility: hidden;
+    opacity: 0;
+    transition: none; // 로딩 중 애니메이션 제거
+    
     @include md {
-        display: flex;
+        visibility: visible;
+        opacity: 1;
     }
 }
 
@@ -21,25 +26,48 @@
 .search-input {
     width: 100%;
     height: 100%;
+    // MUI 스타일보다 우선 적용되도록 specificity 증가
+    
+    .MuiAutocomplete-root {
+        // 초기 렌더링 시 안정성 확보
+        min-height: 32px;
+    }
 
     .MuiAutocomplete-inputRoot {
         padding-right: 0 !important;
+        // 폰트 로딩 중에도 레이아웃 유지
+        font-family: $font-family;
+        font-size: 16px;
+        line-height: 1.4;
     }
 
     .MuiInputBase-input {
-        font-family: $font-family;
-        font-size: 16px;
-        font-weight: 500;
+        font-family: $font-family !important;
+        font-size: 16px !important;
+        font-weight: 500 !important;
         padding-bottom: 2px !important;
         color: var(--primary-text-color) !important;
+        // FOUC 방지를 위한 안정적인 기본값
+        background-color: transparent !important;
+        border: none !important;
+        outline: none !important;
     }
 
     .MuiInput-underline:before {
-        border-bottom-color: var(--primary-text-color);
-        border-bottom-width: 1px;
+        border-bottom-color: var(--primary-text-color) !important;
+        border-bottom-width: 1px !important;
     }
 
     .MuiInput-underline:after {
-        border-bottom-color: var(--primary-text-color);
+        border-bottom-color: var(--primary-text-color) !important;
+    }
+    
+    // 로딩 중 깜빡임 방지
+    .MuiInput-underline {
+        transition: none !important;
+        
+        &:hover:not(.Mui-disabled):before {
+            border-bottom-width: 1px !important;
+        }
     }
 }


### PR DESCRIPTION
## 문제 설명
페이지 새로고침 시 검색 입력창이 찰나의 순간 정렬이 깨지는 FOUC(Flash of Unstyled Content) 현상 발생

## 해결 방법
### 1. post-search 컴포넌트 개선
- `display: none` → `visibility: hidden` + `opacity: 0` 방식으로 변경
- 레이아웃 공간을 유지하면서 시각적으로만 숨김
- CSS 우선순위 강화로 안정적인 초기 상태 보장

### 2. page-header 레이아웃 안정성 보강
- `min-height` 설정으로 초기 렌더링 높이 고정
- flexbox 안정성을 위한 추가 속성 설정
- `flex-shrink: 0`으로 검색창 영역 축소 방지

## 결과
- ✅ 페이지 새로고침 시 검색창 정렬 깨짐 현상 해결
- ✅ 반응형 전환 시 부드러운 애니메이션 유지
- ✅ 레이아웃 안정성 확보

## 테스트
- 로컬 빌드 테스트 완료
- 반응형 동작 확인 완료