### PR TITLE
DOM 구조 수정으로 FOUC 완전 해결

### DIFF
--- a/src/components/post-search/index.js
+++ b/src/components/post-search/index.js
@@ -6,24 +6,24 @@ import './style.scss';
 
 function PostSearch({ posts }) {
   return (
-    <Autocomplete
-      disableClearable
-      options={posts}
-      onInputChange={(event, value, reason) => {
-        if (reason === 'reset' && value) {
-          const item = posts.find((item) => item.title === value);
-          if (!item) return;
-          navigate(item.slug);
+    <div className="search-input-wrapper">
+      <Autocomplete
+        disableClearable
+        options={posts}
+        onInputChange={(event, value, reason) => {
+          if (reason === 'reset' && value) {
+            const item = posts.find((item) => item.title === value);
+            if (!item) return;
+            navigate(item.slug);
+          }
+        }}
+        filterOptions={(options, { inputValue }) =>
+          options.filter(
+            ({ title, categories }) => title.includes(inputValue) || categories.includes(inputValue),
+          )
         }
-      }}
-      filterOptions={(options, { inputValue }) =>
-        options.filter(
-          ({ title, categories }) => title.includes(inputValue) || categories.includes(inputValue),
-        )
-      }
-      getOptionLabel={(option) => option.title}
-      renderInput={(params) => (
-        <div className="search-input-wrapper">
+        getOptionLabel={(option) => option.title}
+        renderInput={(params) => (
           <TextField
             {...params}
             id="post-search-input"
@@ -37,10 +37,10 @@ function PostSearch({ posts }) {
               endAdornment: <SearchIcon className="search-icon" />,
             }}
           />
-        </div>
-      )}
-      noOptionsText="해당하는 글이 없습니다."
-    />
+        )}
+        noOptionsText="해당하는 글이 없습니다."
+      />
+    </div>
   );
 }
 export default PostSearch;


### PR DESCRIPTION
## 근본 원인 발견
이전 수정에서 CSS는 올바르게 작성되었지만, DOM 구조가 잘못되어 있었습니다:

**기존 구조 (문제)**:
```html
<div class="MuiAutocomplete-root">  <\!-- MUI 최상위 -->
    <div class="search-input-wrapper">  <\!-- 안쪽에 위치 -->
```

**수정된 구조**:
```html
<div class="search-input-wrapper">  <\!-- 최상위 -->
    <div class="MuiAutocomplete-root">  <\!-- 안쪽에 위치 -->
```

## 수정 내용
### PostSearch 컴포넌트 구조 변경
- `search-input-wrapper`를 `Autocomplete` 외부로 이동
- `renderInput` 내부가 아닌 컴포넌트 최상위 레벨로 위치 변경
- CSS의 `visibility: hidden/visible` 제어가 올바르게 작동하도록 수정

## 결과
- ✅ CSS FOUC 방지 코드가 정상 작동
- ✅ MUI 기본 스타일이 우리의 visibility 설정을 무시하지 못함
- ✅ 페이지 새로고침 시 검색창 깜빡임 완전 제거

## 테스트
- 로컬 빌드 성공 확인
- DOM 구조 변경으로 인한 사이드 이펙트 없음