### PR TITLE
fix: Google AdSense 광고 코드 제거

### DIFF
--- a/src/components/seo/index.js
+++ b/src/components/seo/index.js
@@ -86,20 +86,11 @@ function Seo({ description, title }) {
           name: `google-site-verification`,
           content: ``, // Google Search Console 인증 시 추가 필요
         },
-        {
-          name: `google-adsense-account`,
-          content: `ca-pub-6754483654653335`,
-        },
       ]}
     >
       <script type="application/ld+json">
         {JSON.stringify(structuredData)}
       </script>
-      <script
-        async
-        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6754483654653335"
-        crossOrigin="anonymous"
-      />
     </Helmet>
   );
 }

--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,3 +1,0 @@
-# ads.txt for jonny-cho.github.io
-# Google AdSense
-google.com, pub-6754483654653335, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- seo 컴포넌트(`src/components/seo/index.js`)에서 AdSense 메타태그(`google-adsense-account`) 및 auto ads 스크립트(`adsbygoogle.js`) 제거
- `static/ads.txt` 파일 삭제

## Test plan
- [x] `npm run build` 정상 완료 확인
- [x] 빌드 산출물(`public/`)에 adsbygoogle/googlesyndication/ads.txt 관련 코드가 남아있지 않음을 확인